### PR TITLE
ci: broaden build triggers (push to main + feature branches) and add …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,16 @@ on:
   pull_request:
     branches: [ "main" ]
   push:
-    branches: [ "main", "ci/**", "feat/**", "fix/**" ]
+    branches:
+      - "main"
+      - "ci/**"
+      - "feat/**"
+      - "fix/**"
+      - "chore/**"
+      - "docs/**"
+      - "repo/**"
+      - "refactor/**"
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
…workflow_dispatch

﻿## PR checklist
- [ ] Build zöld (GA uild workflow)
- [ ] Tesztek lefedve / frissítve
- [ ] Dokumentáció (README / OpenAPI) frissítve, ha kell
- [ ] Breaking change? Leírás + migráció

## Leírás
Röviden: mit és miért módosít ez a PR?

## Megjegyzések a reviewernek
„Fixes ‘No jobs were run’ emails by widening push triggers; adds manual run.”