### PR TITLE
docs: add DEV Quickstart for dev scripts (Windows)

### DIFF
--- a/docs/DEV_QUICKSTART.md
+++ b/docs/DEV_QUICKSTART.md
@@ -1,0 +1,13 @@
+﻿# DEV Quickstart — performance-app-backend
+
+Ez a rövid útmutató segít a fejlesztői környezet gyors indításában/leállításában, a health check futtatásában, a tesztek indításában és tipikus hibák megoldásában (Windows + PowerShell).
+
+## Előfeltételek
+- Docker Desktop (Engine fusson)
+- JDK 21 (a `dev-start.bat` autodetektálja)
+- PowerShell (admin jog ajánlott)
+- 8080-as port legyen szabad
+
+## Indítás
+```powershell
+.\dev-start.bat


### PR DESCRIPTION
## What
- Add `docs/DEV_QUICKSTART.md`:
  - dev-start/dev-stop használat
  - health check parancs
  - tesztek futtatása (JDK 21)
  - tipikus hibák (8080 foglalt, Docker, Java 8 stb.)
  - hasznos parancsok és EOL megjegyzések

## Why
- Új fejlesztőknek és jövőbeli önmagunknak gyors, egyoldalas indítási útmutató.
- Egységes fejlesztői élmény Windows + PowerShell környezetben.

## How to test
1) Futtasd: `.\dev-start.bat`
2) Health: `iwr http://localhost:8080/api/healthz | Select-Object -ExpandProperty Content` → `ok`
3) Teszt: `.\gradlew clean test` (JDK 21)

