### PR TITLE
docs(readme): link DEV Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ Protection check note
 
 
 _Smoke test:_ branch protection rules active.
+## Development Quickstart
+
+See [docs/DEV_QUICKSTART.md](docs/DEV_QUICKSTART.md).


### PR DESCRIPTION
﻿## What
Add README section linking to docs/DEV_QUICKSTART.md.

## Why
So new devs (és a jövőbeli énünk) gyorsan megtalálják az indítás/leállítás, health check és teszt útmutatót.

## How to test
- Open README on GitHub → verify the new “Development Quickstart” section appears and the link resolves.
