### PR TITLE
ci: add Gradle test workflow (Java 21) for PRs and main

### DIFF
--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -18,6 +18,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Make gradlew executable & normalize EOL
+        run: |
+          git config core.autocrlf false
+          sed -i 's/\r$//' gradlew
+          chmod +x gradlew
 
       - name: Validate Gradle Wrapper (non-blocking)
         uses: gradle/wrapper-validation-action@v2


### PR DESCRIPTION
## What
- Add GitHub Actions workflow (.github/workflows/gradle-tests.yml)
- Runs `./gradlew --no-daemon clean test` on PRs targeting `main` and on pushes to `main`
- Java 21 (Temurin), Gradle cache, wrapper validation

## Why
- Automatikus tesztfuttatás PR-okra
- Gyorsabb visszajelzés, stabil főág

## How to test
1) Open this PR → checks should start automatically.
2) If green, merge.
